### PR TITLE
chore: gitignore every Eclipse JDT produced file and folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,23 @@
-*.log
-hs_err_pid*
-/.idea
-/target
-/local
+# Maven and Gradle files
+target
+build
+
+# Eclipse, Netbeans and IntelliJ files
+.*
+!/.github
+!/.ci
+!/.mvn
+!.gitignore
+!.gitattributes
+/nbproject
+*.ipr
+*.iws
 *.iml
+
+# Repository wide ignore mac DS_Store files
+.DS_Store
+
+# Various local artifacts
 dependency-reduced-pom.xml
 /results
 /async-profiler*/**/*


### PR DESCRIPTION
.settings and others show up when using the Claude Code with Java LSP provided by the JDT-LS project in